### PR TITLE
Add alternate constructor and method

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This library is based on [Ruslan Koptev](https://github.com/rkoptev) ACS712
 current sensors library for Arduino <https://github.com/rkoptev/ACS712-arduino>.
 This library is modified so that it can be used with ZMPT101B voltage sensor
 with the same code principle.
+An alternate constructor and method are also included to provide a similar structure
+to that in the [Rob Tillaart](https://github.com/RobTillaart/ACS712) library.
 
 ## Methods
 
@@ -16,9 +18,18 @@ with the same code principle.
 ZMPT101B(uint8_t pin, uint16_t frequency = DEFAULT_FREQUENCY);
 ```
 
-Constructor has a parameters `pin` for analog input to tell where is connected
+Basic constructor has a parameters `pin` for analog input to tell where is connected
 and the `frequency` value of the AC voltage that the sensor will measure (by
 default 50.0Hz).
+
+```c++
+ZMPT101B (uint8_t pin, float adcVref, uint16_t adcScale, float sensitivity);
+```
+
+Alternate constructor provides a similar structur to that used in the Tillaart ACS712
+library. It has a parameters `pin` for analog input to tell where is connected,
+`adcVref` to identify the ADC reference voltage, `adcScale` to set the ADC scale and
+`sensitivity` to set the sensitivity of the sensor.
 
 ### Reading RMS Voltage Value
 
@@ -31,6 +42,13 @@ By default this method will only calculate the RMS value of one period wave. If
 you want the calculation to be done over several periods you can specify how
 many iterations you want. Reading more than once will usually return a more
 precise value however, sometimes it will take longer.
+
+```c++
+float getRmsVoltage(uint16_t frequency, uint8_t loopCount)
+```
+
+This method allows us to specify the input voltage frequency, from which the
+measurement period is derived, at the time of measurement.
 
 ### Set Sensitivity
 
@@ -86,7 +104,8 @@ serial monitor. Wait until the `sensitivity` value is displayed and then copy it
 
 #### 2. Start measurement
 
-Open the [simple_usage.ino](/examples/simple_usage/simple_usage.ino) example
+Open either the [simple_usage.ino](/examples/simple_usage/simple_usage.ino) example
 then change the `SENSITIVITY` value (seventh line) based on the value you got in
-the previous process. Upload the code then open the serial monitor to observe
-the displayed voltage value.
+the previous process or use the alternate constructor in the [alternate_usage.ino](/examples/simple_usage/alternate_usage.ino)
+example to set the sensitivity in the sensor constructor. Upload the code then open
+the serial monitor to observe the displayed voltage value.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ default 50.0Hz).
 ZMPT101B (uint8_t pin, float adcVref, uint16_t adcScale, float sensitivity);
 ```
 
-Alternate constructor provides a similar structur to that used in the Tillaart ACS712
-library. It has a parameters `pin` for analog input to tell where is connected,
+Alternate constructor provides a similar structure to that used in the Tillaart ACS712
+library. It has parameters `pin` to identify the ADC to which the sensor is connected,
 `adcVref` to identify the ADC reference voltage, `adcScale` to set the ADC scale and
 `sensitivity` to set the sensitivity of the sensor.
 

--- a/examples/simple_usage/alternate_usage.ino
+++ b/examples/simple_usage/alternate_usage.ino
@@ -1,0 +1,27 @@
+/*
+ * This program shows the use of an alternate constructor and method to use this library.
+*/
+
+#include <ZMPT101B.h>
+
+uint16_t signalFrequency = 50;	// 50Hz
+uint8_t sampleCycles = 5;			  // Sampling cycles
+float zmptSensitivity = 334;		// Sensor calibration
+uint16_t adcScale = 4095;				// 12-bit resolution
+float adcVref = 2.4;						// 2.4V
+
+// ZMPT101B sensor output connected to analog pin A0
+// Change the sensitivity value based on value you got from the calibrate example
+ZMPT101B voltageSensor(A0, adcVref, adcScale, zmptSensitivity);
+
+void setup() {
+  Serial.begin(115200);
+}
+
+void loop() {
+  // read the voltage and then print via Serial.
+  float voltage = voltageSensor.getRmsVoltage(signalFrequency, sampleCycles);
+  Serial.println(voltage);
+
+  delay(1000);
+}

--- a/src/ZMPT101B.cpp
+++ b/src/ZMPT101B.cpp
@@ -7,6 +7,23 @@ ZMPT101B::ZMPT101B(uint8_t pin, uint16_t frequency)
 {
 	this->pin = pin;
 	period = 1000000 / frequency;
+	this->adcVref = VREF;
+	this->adcScale = ADC_SCALE;
+	pinMode(pin, INPUT);
+}
+
+/// @brief Alternate ZMPT101B constructor
+/// @param pin analog pin that ZMPT101B connected to.
+/// @param adcVref ADC max voltage
+/// @param adcScale ADC resolution
+/// @param sensitivity module sensitivity
+ZMPT101B::ZMPT101B(uint8_t pin, float adcVref, uint16_t adcScale, float sensitivity)
+{
+	this->pin = pin;
+	period = 1000000 / frequency;
+	this->adcVref = adcVref;
+	this->adcScale = adcScale;
+	this->sensitivity = sensitivity;
 	pinMode(pin, INPUT);
 }
 
@@ -35,6 +52,16 @@ int ZMPT101B::getZeroPoint()
 }
 
 /// @brief Calculate root mean square (RMS) of AC valtage
+/// @param frequency AC system frequency
+/// @param loopCount Loop count to calculate
+/// @return root mean square (RMS) of AC valtage
+float ZMPT101B::getRmsVoltage(uint16_t frequency, uint8_t loopCount)
+{
+	period = 1000000 / frequency;
+	return getRmsVoltage(loopCount);
+}
+
+/// @brief Calculate root mean square (RMS) of AC valtage
 /// @param loopCount Loop count to calculate
 /// @return root mean square (RMS) of AC valtage
 float ZMPT101B::getRmsVoltage(uint8_t loopCount)
@@ -57,7 +84,7 @@ float ZMPT101B::getRmsVoltage(uint8_t loopCount)
 			measurements_count++;
 		}
 
-		readingVoltage += sqrt(Vsum / measurements_count) / ADC_SCALE * VREF * sensitivity;
+		readingVoltage += sqrt(Vsum / measurements_count) / adcScale * adcVref * sensitivity;
 	}
 
 	return readingVoltage / loopCount;

--- a/src/ZMPT101B.h
+++ b/src/ZMPT101B.h
@@ -15,19 +15,30 @@
 #elif defined(ESP32)
 	#define ADC_SCALE 4095.0
 	#define VREF 3.3
+#elif defined(__ASR_Arduino__)
+	#define ADC_SCALE 4095.0
+	#define VREF 2.4
+#else
+	#define ADC_SCALE 4095.0
+	#define VREF 3.3
 #endif
 
 class ZMPT101B
 {
 public:
 	ZMPT101B (uint8_t pin, uint16_t frequency = DEFAULT_FREQUENCY);
+	ZMPT101B (uint8_t pin, float adcVref, uint16_t adcScale, float sensitivity);
 	void     setSensitivity(float value);
 	float 	 getRmsVoltage(uint8_t loopCount = 1);
+	float 	 getRmsVoltage(uint16_t frequency, uint8_t loopCount);
 
 private:
 	uint8_t  pin;
 	uint32_t period;
 	float 	 sensitivity = DEFAULT_SENSITIVITY;
+	uint16_t frequency = DEFAULT_FREQUENCY;
+	float    adcVref;
+	uint16_t adcScale;
 	int 	 getZeroPoint();
 };
 


### PR DESCRIPTION
1. An additional definition [\_\_ASR_Arduino\_\_] is included to set parameters for an ASR MCU.
2. An alternate constructor `ZMPT101B(uint8_t pin, float adcVref, uint16_t adcScale, float sensitivity)` and method `float getRmsVoltage(uint16_t frequency, uint8_t loopCount)` are included to provide a level of compatibility with those used in the [Tillaart ACS712 library](https://github.com/RobTillaart/ACS712), since the ZMPT101B voltage sensor is often used in conjunction with the ACS712 current sensor.
3. Three additional variables, `frequency`,  `adcVref` and `adcScale`, are defined to provide consistency of usage between the different constructors and methods.